### PR TITLE
Add IDFA usage support

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -42,6 +42,8 @@ platform :ios do
         app_version: version_number,
         automatic_release: automatic_release,
         submit_for_review: submit_for_review,
+        submission_information: cru_submission_information
+        )
     )
 
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")
@@ -195,6 +197,27 @@ platform :ios do
         version: "2",
         custom_color: "green"
     )
+  end
+
+  lane :cru_submission_information do
+    {
+        export_compliance_available_on_french_store: false,
+        export_compliance_contains_proprietary_cryptography: false,
+        export_compliance_contains_third_party_cryptography: false,
+        export_compliance_is_exempt: false,
+        export_compliance_uses_encryption: false,
+        export_compliance_app_type: nil,
+        export_compliance_encryption_updated: false,
+        export_compliance_compliance_required: false,
+        export_compliance_platform: "ios",
+        content_rights_contains_third_party_content: false,
+        content_rights_has_rights: false,
+        add_id_info_limits_tracking: true,
+        add_id_info_serves_ads: ENV['CRU_IDFA_SERVES_ADS'] || false,
+        add_id_info_tracks_action: ENV['CRU_IDFA_TRACKS_ACTION'] || false,
+        add_id_info_tracks_install: ENV['CRU_IDFA_TRACKS_INSTALL'] || false,
+        add_id_info_uses_idfa: ENV['CRU_IDFA_IS_ENABLED'] || false
+    }
   end
 end
 

--- a/Fastfile
+++ b/Fastfile
@@ -220,7 +220,7 @@ platform :ios do
     )
   end
 
-  def cru_submission_information do
+  def cru_submission_information
     {
         export_compliance_available_on_french_store: false,
         export_compliance_contains_proprietary_cryptography: false,

--- a/Fastfile
+++ b/Fastfile
@@ -199,7 +199,7 @@ platform :ios do
     )
   end
 
-  lane :cru_submission_information do
+  def cru_submission_information do
     {
         export_compliance_available_on_french_store: false,
         export_compliance_contains_proprietary_cryptography: false,

--- a/Fastfile
+++ b/Fastfile
@@ -43,7 +43,6 @@ platform :ios do
         automatic_release: automatic_release,
         submit_for_review: submit_for_review,
         submission_information: cru_submission_information
-        )
     )
 
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")


### PR DESCRIPTION
GodTools, and likely other apps in the future, need to submit data to Apple indicating that the app is using the IDFA (device identifier for advertising purposes). If the app uses this value, but fails to answer yes (true), then the build is permanently rejected. This PR allows project to submit this value, and one or more of three options about how it is used. They all default to `false`

NOTE: this PR is untested as we have not had a build to release to the app store since writing it.