### PR TITLE
Simplify release params

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -22,7 +22,7 @@ platform :ios do
     end
 
     target = ENV["CRU_TARGET"]
-    submit_for_review = options.key?(:submit) && options[:submit] || false
+
     automatic_release = options.key?(:auto_release) && options[:auto_release] || false
     include_metadata = options.key?(:include_metadata) && options[:include_metadata] || false
     
@@ -41,7 +41,7 @@ platform :ios do
         skip_metadata: !include_metadata,
         app_version: version_number,
         automatic_release: automatic_release,
-        submit_for_review: submit_for_review,
+        submit_for_review: true,
     )
 
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")

--- a/Fastfile
+++ b/Fastfile
@@ -45,10 +45,8 @@ platform :ios do
     )
 
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")
+    cru_notify_users(message: "Build has been submitted for review and will be #{automatic_release ? 'automatically' : 'manually'} released.")
 
-    if submit_for_review
-      cru_notify_users(message: "Build has been submitted for review and will be #{automatic_release ? 'automatically' : 'manually'} released.")
-    end
   end
 
   desc "Push a new (beta) release build to TestFlight"


### PR DESCRIPTION
Remove the ability to pass `submit_for_review` on release builds. I don't know what I was thinking when I wrote it, but I don't think there's really a use case for running this job and _not_ wanting to submit the build for review.