### PR TITLE
Commit version bump

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -191,13 +191,15 @@ platform :ios do
   end
 
   lane :cru_bump_version_number do |params|
-    return unless params[:version_number].eql? ENV['TRAVIS_TAG']
+    if "v#{params[:version_number]}".eql? ENV['TRAVIS_TAG']
 
-    sh('git fetch --unshallow')
-    sh('git checkout master')
-    version_number = increment_version_number(bump_type: 'patch')
-    cru_update_commit(message: "[skip ci] Bumping version number to #{version_number} for next build")
-    push_to_git_remote
+      sh('git remote set-branches --add origin master')
+      sh('git fetch origin master:master')
+      sh('git checkout master')
+      version_number = increment_version_number(bump_type: 'patch')
+      cru_update_commit(message: "[skip ci] Bumping version number to #{version_number} for next build")
+      push_to_git_remote
+    end
   end
 
   lane :cru_notify_users do |options|
@@ -209,4 +211,3 @@ platform :ios do
     )
   end
 end
-

--- a/Fastfile
+++ b/Fastfile
@@ -44,6 +44,8 @@ platform :ios do
         submit_for_review: submit_for_review,
     )
 
+    cru_bump_version_number(version_number: version_number)
+
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")
 
     if submit_for_review
@@ -186,6 +188,16 @@ platform :ios do
     info_file_path = "#{ENV['CRU_SCHEME']}/Info.plist"
     git_commit(path:[project_file_path, info_file_path],
                message: options[:message])
+  end
+
+  lane :cru_bump_version_number do |params|
+    return unless params[:version_number].eql? ENV['TRAVIS_TAG']
+
+    sh('git fetch --unshallow')
+    sh('git checkout master')
+    version_number = increment_version_number(bump_type: 'patch')
+    cru_update_commit(message: "[skip ci] Bumping version number to #{version_number} for next build")
+    push_to_git_remote
   end
 
   lane :cru_notify_users do |options|


### PR DESCRIPTION
This PR adds support for incrementing the version number and pushing that commit to the GH `master` branch. Perhaps the branch name should be parameterized, but for now `master` seems the reasonable place to push to.

This commit will only happen when the version number (external-facing version number) matches the value set in the `TRAVIS_TAG` environment variable. This will prevent potentially weird changes from happening in case a build occurs on a different version number or from an unexpected point in the git history. The base case is that the release build comes from the latest master commit, and in this case the version bump should happen.