### PR TITLE
MPDX-5684 create ad hoc ipa

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -144,6 +144,17 @@ platform :ios do
         profile_name: profile_name
     )
 
+      # Travis requires a keychain to be created to store the certificates in, however
+    # using this utility to create a keychain locally will really mess up local keychains
+    # and is not required for a successful build.
+    create_keychain(
+        name: ENV["MATCH_KEYCHAIN_NAME"],
+        password: ENV["MATCH_PASSWORD"],
+        default_keychain: true,
+        unlock: true,
+        timeout: 3600,
+        add_to_search_list: true
+      )
     cru_fetch_certs(type: type)
 
     if ENV["CRU_SKIP_COCOAPODS"].nil?
@@ -183,23 +194,11 @@ platform :ios do
   end
 
   lane :cru_fetch_certs do |options|
-    # Travis requires a keychain to be created to store the certificates in, however
-    # using this utility to create a keychain locally will really mess up local keychains
-    # and is not required for a successful build
-    create_keychain(
-        name: ENV["MATCH_KEYCHAIN_NAME"],
-        password: ENV["MATCH_PASSWORD"],
-        default_keychain: true,
-        unlock: true,
-        timeout: 3600,
-        add_to_search_list: true
-    )
-
-    match(type: options[:type],
-          username: ENV['CRU_FASTLANE_USERNAME'],
-          app_identifier: ENV['CRU_APP_IDENTIFIER'],
-          keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
-          keychain_password: ENV["MATCH_PASSWORD"])
+  match(type: options[:type],
+    username: ENV['CRU_FASTLANE_USERNAME'],
+    app_identifier: ENV['CRU_APP_IDENTIFIER'],
+    keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+    keychain_password: ENV["MATCH_PASSWORD"])
 
   end
 

--- a/Fastfile
+++ b/Fastfile
@@ -75,18 +75,6 @@ platform :ios do
     )
 
     cru_update_commit(message: "[skip ci] Build number bump to ##{build_number}")
-
-    github_ipa_release_path = ipa_path
-    unless ENV["CRU_ADHOC_PROFILE_NAME"].nil?
-      github_ipa_release_path = cru_build_app(profile_name: ENV["CRU_ADHOC_PROFILE_NAME"], type: "adhoc", export_method: "ad-hoc")
-    end
-
-    cru_push_release_to_github(
-        version_number: version_number,
-        project_name: ENV["CRU_TARGET"],
-        ipa_path: github_ipa_release_path
-    )
-
     push_to_git_remote
 
     cru_notify_users(message: "#{target} iOS Beta Build ##{build_number} released to TestFlight.")
@@ -174,6 +162,24 @@ platform :ios do
             }
         }
     )
+  end
+
+  lane :cru_build_adhoc do |options|
+    unless ENV["CRU_ADHOC_PROFILE_NAME"].nil?
+      target = ENV["CRU_TARGET"]
+      version_number =  get_version_number(
+        target: target
+      )
+
+      github_ipa_release_path = cru_build_app(profile_name: ENV["CRU_ADHOC_PROFILE_NAME"], type: "adhoc", export_method: "ad-hoc")
+      cru_push_release_to_github(
+        version_number: version_number,
+        project_name: target,
+        ipa_path: github_ipa_release_path
+      )
+
+      push_to_git_remote
+    end
   end
 
   lane :cru_fetch_certs do |options|

--- a/Fastfile
+++ b/Fastfile
@@ -146,17 +146,17 @@ platform :ios do
 
     unless options.key?(:skip_create_keychain) && options[:skip_create_keychain]
       # Travis requires a keychain to be created to store the certificates in, however
-    # using this utility to create a keychain locally will really mess up local keychains
-    # and is not required for a successful build.
-    # It also cannot be called more than once (in the case that cru_build_app happens more than once in the same execution)
-    create_keychain(
-        name: ENV["MATCH_KEYCHAIN_NAME"],
-        password: ENV["MATCH_PASSWORD"],
-        default_keychain: true,
-        unlock: true,
-        timeout: 3600,
-        add_to_search_list: true
-      )
+      # using this utility to create a keychain locally will really mess up local keychains
+      # and is not required for a successful build.
+      # It also cannot be called more than once (in the case that cru_build_app happens more than once in the same execution)
+      create_keychain(
+          name: ENV["MATCH_KEYCHAIN_NAME"],
+          password: ENV["MATCH_PASSWORD"],
+          default_keychain: true,
+          unlock: true,
+          timeout: 3600,
+          add_to_search_list: true
+        )
     end
 
     cru_fetch_certs(type: type)
@@ -203,12 +203,11 @@ platform :ios do
   end
 
   lane :cru_fetch_certs do |options|
-  match(type: options[:type],
-    username: ENV['CRU_FASTLANE_USERNAME'],
-    app_identifier: ENV['CRU_APP_IDENTIFIER'],
-    keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
-    keychain_password: ENV["MATCH_PASSWORD"])
-
+    match(type: options[:type],
+      username: ENV['CRU_FASTLANE_USERNAME'],
+      app_identifier: ENV['CRU_APP_IDENTIFIER'],
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_PASSWORD"])
   end
 
   lane :cru_update_commit do |options|


### PR DESCRIPTION
https://jira.cru.org/browse/MPDX-5684

Merging develop into master builds the distribution beta properly and submits to Testflight, but the ad hoc build is still failing.  I was able to successfully build the ad hoc alone, but there seems to be an issue with building two separate builds back to back: https://travis-ci.com/CruGlobal/mpdx-ios/builds/92597896#L1838

Looking at https://github.com/fastlane/fastlane/issues/13270#issuecomment-422343705, it looks like there's an issue with calling create_keychain twice in the same run.  I added an option to skip keychain creation that also has to be added to travis.yml: https://github.com/CruGlobal/mpdx-ios/pull/613