### PR TITLE
Update Android keystore location to make it relative from the project root

### DIFF
--- a/android/Fastfile
+++ b/android/Fastfile
@@ -46,7 +46,7 @@ platform :android do
   end
 
   lane :cru_build_app do
-    keystore_filename = File.expand_path(ENV['GOOGLE_PLAY_UPLOAD_KEYSTORE'])
+    keystore_filename = File.expand_path(ENV['GOOGLE_PLAY_UPLOAD_KEYSTORE'], File.expand_path('..'))
     task = ENV['CRU_GRADLE_TASK'] || 'clean assembleRelease'
 
     gradle(task: task,

--- a/android/Fastfile
+++ b/android/Fastfile
@@ -46,12 +46,8 @@ platform :android do
   end
 
   lane :cru_build_app do
-    keystore_filename = ENV['GOOGLE_PLAY_UPLOAD_KEYSTORE']
+    keystore_filename = File.expand_path(ENV['GOOGLE_PLAY_UPLOAD_KEYSTORE'])
     task = ENV['CRU_GRADLE_TASK'] || 'clean assembleRelease'
-
-    # this was mind numbing to figure out, no matter which place I put the keystore, the gradle build would
-    # expect it in the other place. the only working and dumb solution I found was to put it in both places.
-    sh('cp', "../app/#{keystore_filename}", "../#{keystore_filename}")
 
     gradle(task: task,
            print_command: false,


### PR DESCRIPTION
the android gradle plugin resolves `android.injected.signing.store.file` relative to 2 different paths in different tasks. The only way to fix this is to either duplicate the file in both locations, or provide an absolute path.

This PR converts the potentially relative path to an absolute path relative to the project root directory. Logic in the Fastfile executes within the fastlane sub directory, so we needed to go up one directory before resolving the relative path. https://docs.fastlane.tools/advanced/fastlane/#directory-behavior