### PR TITLE
Disable submit_for_review

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
         skip_metadata: !include_metadata,
         app_version: version_number,
         automatic_release: automatic_release,
-        submit_for_review: true,
+        submit_for_review: false,
         submission_information: cru_submission_information
     )
 

--- a/Fastfile
+++ b/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
 
     automatic_release = options.key?(:auto_release) && options[:auto_release] || false
     include_metadata = options.key?(:include_metadata) && options[:include_metadata] || false
-    submit_for_review = options.key?(:submit) && options[:submit] || true
+    submit_for_review = options.key?(:submit) ? options[:submit] : true
     
     version_number = get_version_number(
         target: target

--- a/Fastfile
+++ b/Fastfile
@@ -25,6 +25,7 @@ platform :ios do
 
     automatic_release = options.key?(:auto_release) && options[:auto_release] || false
     include_metadata = options.key?(:include_metadata) && options[:include_metadata] || false
+    submit_for_review = options.key?(:submit) && options[:submit] || true
     
     version_number = get_version_number(
         target: target
@@ -41,14 +42,16 @@ platform :ios do
         skip_metadata: !include_metadata,
         app_version: version_number,
         automatic_release: automatic_release,
-        submit_for_review: false,
+        submit_for_review: submit_for_review,
         submission_information: cru_submission_information
     )
 
     cru_bump_version_number(version_number: version_number)
 
     cru_notify_users(message: "#{target} iOS Release Build #{version_number} (#{build_number}) submitted to App Store.")
-    cru_notify_users(message: "Build has been submitted for review and will be #{automatic_release ? 'automatically' : 'manually'} released.")
+    if submit_for_review
+      cru_notify_users(message: "Build has been submitted for review and will be #{automatic_release ? 'automatically' : 'manually'} released.")
+    end
 
   end
 


### PR DESCRIPTION
Submission to the app store is failing due to the release not having release notes. This changes that behavior by only creating the release in the app store and not submitting it for review until an app manager goes and fills in any missing details.