### PR TITLE
Pass App Store credentials to latest_testflight_build_number

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -60,7 +60,10 @@ platform :ios do
     target = ENV["CRU_TARGET"]
 
     build_number = increment_build_number({
-      build_number: latest_testflight_build_number + 1
+      build_number: latest_testflight_build_number({
+        username: ENV['CRU_FASTLANE_USERNAME'],
+        app_identifier: ENV["CRU_APP_IDENTIFIER"],
+      }) + 1
     })
     version_number =  get_version_number(
         target: target


### PR DESCRIPTION
`latest_testflight_build_number` failed cuz I didn't provide a username https://github.com/CruGlobal/missionhub-react-native/runs/1691565485?check_suite_focus=true#step:11:433.

I don't think this is going to be enough. https://github.com/fastlane/fastlane/issues/16620 makes it sound like it won't use the password from the testflight upload and requires an api_key. We can try anyways. I can look into setting up and api key but that will probably require encrypting a key file like what we've done for Android and I wanted to make sure we wanted to go that route first.