### PR TITLE
Fallback to empty string value for OneSky secret key

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -333,7 +333,7 @@ platform :ios do
     one_sky_localizations_string = options[:one_sky_localizations] || ENV["ONESKY_LOCALIZATIONS"]
     one_sky_project_id = options[:one_sky_project_id] || ENV["ONESKY_PROJECT_ID"]
     one_sky_public_key = options[:one_sky_public_key] || ENV["ONESKY_PUBLIC_KEY"]
-    one_sky_secret_key = options[:one_sky_secret_key] || ENV["ONESKY_SECRET_KEY"]
+    one_sky_secret_key = options[:one_sky_secret_key] || ENV["ONESKY_SECRET_KEY"] || ""
     
     one_sky_localizations_array = one_sky_localizations_string.split(",")
 


### PR DESCRIPTION
I was getting an error during OneSky downloading when trying to set the OneSky secret key for the onesky_download action.  Falling back to an empty string if this value isn't provided.

<img width="1285" alt="Screen Shot 2021-11-08 at 9 26 47 AM" src="https://user-images.githubusercontent.com/59846460/140761899-d3ce44ab-1d0d-4332-a2e0-55a105237f79.png">


