### PR TITLE
Add arguments code_coverage and output_directory for fastlane run_tests (scan)

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -303,13 +303,19 @@ platform :ios do
   # fastlane action: https://docs.fastlane.tools/actions/run_tests/
   #
   # options:
+  # - code_coverage: Should code coverage be generated? (Xcode 7 and up).
+  # - output_directory: The directory in which all reports will be stored.
   # - scheme: Specificy the name of the scheme you want to run tests on.  The scheme should be marked as shared in Xcode.
   #
   lane :cru_shared_lane_run_tests do |options|
 
+    code_coverage = options[:code_coverage] || nil
+    output_directory = options[:output_directory] || nil
     scheme = options[:scheme] || ENV["RUN_TESTS_SCHEME"]
 
     run_tests(
+        code_coverage: code_coverage,
+        output_directory: output_directory,
         scheme: scheme
     )
   end


### PR DESCRIPTION
https://docs.fastlane.tools/actions/scan/

Adding arguments for ```code_coverage``` and ```output_directory``` for fastlane run_tests.  

