### PR TITLE
Change English to Base for stringsdict

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -415,7 +415,7 @@ platform :ios do
         directoryName = locale
 
         if locale == "en"
-            directoryName = "English"
+            directoryName = "Base"
         end
             
         directory = "../#{oneSkyDownloadToProjectDirectory}/#{directoryName}.lproj"


### PR DESCRIPTION
This PR is related to (https://github.com/CruGlobal/godtools-swift/pull/2180).  The stringsdict is now located in Base.lproj so will need to be sure OneSky imports it there.